### PR TITLE
Use spread operator for forward compatibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,12 +128,14 @@ pub fn IconButton<'a, S: IconShape>(cx: Scope<'a, IconButtonProps<'a, S>>) -> El
             title: format_args!("{}", cx.props.title.unwrap_or("")),
             disabled: format_args!("{}", if cx.props.disabled { "true" } else { "false" }),
             Icon {
-                class: cx.props.icon_class,
-                disabled: cx.props.disabled,
-                size: cx.props.size,
-                fill: "{cx.props.fill}",
-                disabled_fill: cx.props.disabled_fill,
-                icon: cx.props.icon.clone(),
+                ..IconProps {
+                    class: cx.props.icon_class,
+                    size: cx.props.size,
+                    fill: cx.props.fill,
+                    icon: cx.props.icon.clone(),
+                    disabled: cx.props.disabled,
+                    disabled_fill: cx.props.disabled_fill
+                },
             },
             span {
                 class: format_args!("{}", cx.props.span_class.unwrap_or("")),


### PR DESCRIPTION
The master version of Dioxus does automatic coercion of Option<T> fields into Optional values. This is a breaking change and will be reflected as so in the semver bump when the next version of Dioxus is released.

This crate is affected, but only in a very minor way that is easily remedied by just using the spread syntax for props. This ensures both forward and backward compatibility with Dioxus. 

I wish this change wasn't breaking and it might be reverted, but it's very convenient. 

Anyways - this particular change is small and should be easy to review.